### PR TITLE
Support plone.app.event recurring dx types

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,9 @@ Since all newer versions need plone.app.widgets.
 But 1.1b1 has a install bug. You first need to run the plone.app.registry
 import step manually, then the full setup. This package fixes this bug
 with custom setuphandler, which installs plone.app.event the right way.
+Simply import `ftw.calendar with plone.app.event support` profile.
 
-Since plone.app.event does not supports only plone >= 4.3.
+Since plone.app.event supports only plone >= 4.3.
 We drop the support for all older plone versions.
 
 Other plone.app.event versions may work or not.
@@ -30,6 +31,9 @@ Features
 
 - Integrated: ftw.calendar cares about your calendar settings.
   First day of the week is respected and displayed accordingly.
+
+- CSS Class generator adapter. This allows you to dynamically extend the css
+  class on a event item.
 
 Usage
 =====

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 3.0.0 (unreleased)
 ------------------
 
+- Add css klass generator adapter.
+  [mathias.leimgruber]
+
 - Support recurring events (plone.app.event.dx type).
   [mathias.leimgruber]
 

--- a/ftw/calendar/browser/calendarupdateview.py
+++ b/ftw/calendar/browser/calendarupdateview.py
@@ -1,9 +1,15 @@
 from DateTime import DateTime
+from ftw.calendar.browser.interfaces import IEventCssKlassGenerator
 from plone.app.event.base import dates_for_display
 from plone.app.event.base import get_events
 from plone.app.event.base import RET_MODE_ACCESSORS
 from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
+from Products.ZCatalog.interfaces import ICatalogBrain
+from zope.component import adapts
+from zope.component import queryMultiAdapter
+from zope.interface import implements
+from zope.interface import Interface
 import json
 
 
@@ -26,24 +32,25 @@ class CalendarupdateView(BrowserView):
         self.cache = []
         self.memberid = mtool.getAuthenticatedMember().id
 
-        query = {
+        # Range defined by fullcalender
+        range_ = {
             'start': {
                 'query': DateTime(self.request.get('end')), 'range': 'max'},
             'end': {
                 'query': DateTime(self.request.get('start')), 'range': 'min'}}
 
-        self.get_data_without_recurrence(query)
-        self.get_data_with_recurrence(query)
+        self.get_data_with_recurrence(range_)
+        self.get_data_without_recurrence(range_)
 
         response = self.request.response
         response.setHeader('Content-Type', 'application/x-javascript')
         return json.dumps(self.result, sort_keys=True)
 
-    def get_data_without_recurrence(self, query):
+    def get_data_without_recurrence(self, range_):
 
         if self.context.portal_type == 'Topic':
             brains = self.context.aq_inner.queryCatalog(
-                REQUEST=self.request, **query)
+                REQUEST=self.request, **range_)
         else:
             portal_calendar = getToolByName(self.context, 'portal_calendar')
             catalog = getToolByName(self.context, 'portal_catalog')
@@ -61,7 +68,14 @@ class CalendarupdateView(BrowserView):
 
     def format_brain(self, brain):
         editable = self.memberid in brain.Creator
-        allday = brain.end - brain.start > 1.0
+        # XXX This is no a good solution, the user should decide if it is
+        # a all day event or not unfortunately the old ATEvent does not support
+        # this field - therefore we just say if it's equal or longer than one
+        # day it's displayed as all day event.
+        allday = brain.end - brain.start >= 1.0
+        css = queryMultiAdapter(
+            (brain, self.request),
+            name="event_css_klass_generator").generate_css_klasses()
 
         return {"id": "UID_%s" % (brain.UID),
                 "title": brain.Title,
@@ -70,22 +84,17 @@ class CalendarupdateView(BrowserView):
                 "url": brain.getURL(),
                 "editable": editable,
                 "allDay": allday,
-                "className": "state-" + str(brain.review_state) +
-                (editable and " editable" or ""),
+                "className": css + (editable and " editable" or ""),
                 "description": brain.Description}
 
-    def get_data_with_recurrence(self, query):
-        start = query['start']
-        del query['start']
-        end = query['end']
-        del query['end']
-
+    def get_data_with_recurrence(self, range_):
+        query = {}
         query['path'] = {'depth': -1,
                          'query': '/'.join(self.context.getPhysicalPath())}
 
         occurencies = get_events(self.context,
-                                 start=start,
-                                 end=end,
+                                 start=range_['start'],
+                                 end=range_['end'],
                                  expand=True,
                                  ret_mode=RET_MODE_ACCESSORS,
                                  **query)
@@ -98,6 +107,9 @@ class CalendarupdateView(BrowserView):
 
     def format_occurency(self, occ):
         dates = dates_for_display(occ)
+        css = queryMultiAdapter(
+            (occ, self.request),
+            name="event_css_klass_generator").generate_css_klasses()
 
         return {"id": "UID_%s" % (occ.uid),
                 "title": occ.title,
@@ -106,8 +118,32 @@ class CalendarupdateView(BrowserView):
                 "url": occ.url,
                 "editable": False,
                 "allDay": dates['whole_day'],
-                "className": "",
+                "className": css,
                 "description": occ.description}
+
+
+class DefaultEventCssKlassGenerator(object):
+    implements(IEventCssKlassGenerator)
+    adapts(Interface, Interface)
+
+    def __init__(self, item, request):
+        self.item = item
+        self.request = request
+
+    def generate_css_klasses(self):
+        return ""
+
+
+class BrainEventCssKlassGenerator(object):
+    implements(IEventCssKlassGenerator)
+    adapts(ICatalogBrain, Interface)
+
+    def __init__(self, item, request):
+        self.item = item
+        self.request = request
+
+    def generate_css_klasses(self):
+        return "state-" + str(self.item.review_state)
 
 
 class CalendarDropView(BrowserView):

--- a/ftw/calendar/browser/configure.zcml
+++ b/ftw/calendar/browser/configure.zcml
@@ -51,4 +51,7 @@
       layer=".interfaces.IFtwCalendarLayer"
       />
 
+    <adapter factory=".calendarupdateview.DefaultEventCssKlassGenerator" name="event_css_klass_generator"/>
+    <adapter factory=".calendarupdateview.BrainEventCssKlassGenerator" name="event_css_klass_generator"/>
+
 </configure>

--- a/ftw/calendar/browser/interfaces.py
+++ b/ftw/calendar/browser/interfaces.py
@@ -1,5 +1,16 @@
 from zope.interface import Interface
 
+
 class IFtwCalendarLayer(Interface):
     """Marker interface that defines a Zope 3 browser layer.
     """
+
+
+class IEventCssKlassGenerator(Interface):
+    """Returns css klasses for Event Items in the ftwfullcalendar view. """
+
+    def __init__(item, request):
+        """Adapts item and request"""
+
+    def generate_css_klasses():
+        """ returns a string with css klasses."""

--- a/ftw/calendar/profiles.zcml
+++ b/ftw/calendar/profiles.zcml
@@ -15,7 +15,7 @@
   <genericsetup:registerProfile
       zcml:condition="installed plone.app.event"
       name="paevent"
-      title="ftw.calendar plone.app.event support"
+      title="ftw.calendar with plone.app.event support"
       directory="profiles/paevent"
       description='Fullcalender support for plone.app.event dx type'
       provides="Products.GenericSetup.interfaces.EXTENSION"

--- a/ftw/calendar/tests/test_calendar_update_view.py
+++ b/ftw/calendar/tests/test_calendar_update_view.py
@@ -37,8 +37,8 @@ class TestCalendarUpdateView(TestCase):
                        .within(folder)
                        .titled('Event')
                        .having(description='Description')
-                       .having(start=DateTime('2000/01/01 12:00'))
-                       .having(end=DateTime('2000/01/01 14:00')))
+                       .having(startDate=DateTime('2000/01/01 12:00'))
+                       .having(endDate=DateTime('2000/01/01 14:00')))
 
         expect = {u'id': u'UID_{0}'.format(IUUID(event)),
                   u'title': u'Event',
@@ -53,6 +53,26 @@ class TestCalendarUpdateView(TestCase):
         self.assertEquals(
             expect,
             json.loads(folder.restrictedTraverse('@@ftwcalendar_update')())[0])
+
+    def test_all_day_at_event(self):
+        """This tests the imho wrong behavior of 'all day' events.
+        It's implemented this way because there's no 'all day' field on the
+        default at event content type.
+        An 'all day' event is defined as end - start >= 1.0 """
+
+        folder = create(Builder('folder'))
+        event = create(Builder('at event')
+                       .within(folder)
+                       .titled('Event')
+                       .having(description='Description')
+                       .having(startDate=DateTime('2000/01/01 12:00'))
+                       .having(endDate=DateTime('2000/01/02 12:00')))
+
+        self.assertTrue(
+            json.loads(
+                folder.restrictedTraverse(
+                    '@@ftwcalendar_update')())[0]['allDay'],
+            'It should be an allday event.')
 
     def test_result_using_dx_event(self):
         folder = create(Builder('folder'))
@@ -76,8 +96,8 @@ class TestCalendarUpdateView(TestCase):
                       '2000/01/01 14:00:00 %s' % TZNAME).ISO8601(),
                   u'url': event.absolute_url().decode('utf-8'),
                   u'allDay': False,
-                  u'editable': True,
-                  u'className': u'state- editable',
+                  u'editable': False,
+                  u'className': u'',
                   u'description': u'Description'}
 
         self.assertEquals(
@@ -110,13 +130,13 @@ class TestCalendarUpdateView(TestCase):
         expect_event = {u'id': u'UID_{0}'.format(IUUID(event)),
                         u'title': u'Event',
                         u'start': DateTime(
-                            '2000/01/01 12:00:00 %s' % TZNAME).ISO8601(),
+                            u'2000/01/01 12:00:00 %s' % TZNAME).ISO8601(),
                         u'end': DateTime(
-                            '2000/01/01 14:00:00 %s' % TZNAME).ISO8601(),
+                            u'2000/01/01 14:00:00 %s' % TZNAME).ISO8601(),
                         u'url': event.absolute_url().decode('utf-8'),
                         u'allDay': False,
-                        u'editable': True,
-                        u'className': u'state- editable',
+                        u'editable': False,
+                        u'className': u'',
                         u'description': u'Description'}
 
         self.assertEquals(expect_event, result[0])

--- a/ftw/calendar/tests/test_event_css_klass_generator.py
+++ b/ftw/calendar/tests/test_event_css_klass_generator.py
@@ -1,0 +1,38 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.calendar.testing import FTW_CALENDAR_INTEGRATION_TESTING
+from plone.app.testing import login
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from unittest2 import TestCase
+from zope.component import queryMultiAdapter
+from zope.interface import Interface
+
+
+class TestEventCSSKlassGenerators(TestCase):
+
+    layer = FTW_CALENDAR_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+        setRoles(self.portal, TEST_USER_ID, ['Manager'])
+        login(self.portal, TEST_USER_NAME)
+
+    def test_default_css_generator(self):
+        default = queryMultiAdapter((Interface, Interface),
+                                    name="event_css_klass_generator")
+
+        self.assertEquals("",
+                          default.generate_css_klasses(),
+                          'The default implementation should be empty.')
+
+    def test_brain_css_generator(self):
+        create(Builder('at event'))
+        brain = self.portal.portal_catalog({})[0]
+        default = queryMultiAdapter((brain, Interface),
+                                    name="event_css_klass_generator")
+
+        self.assertEquals("state-",
+                          default.generate_css_klasses())

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import os
 
-version = '2.0.1.dev0'
+version = '3.0.0.dev0'
 
 tests_require = ['ftw.testing [splinter]',
                  'ftw.builder',


### PR DESCRIPTION
- Recurring events are never editable, because you have to edit the origin event, which holds the config for recurrence. 
- Old AT based Event still works.
- They work even together (Old AT Events + p.a.event dx event).
- The old implementation of resizing and dragging items arround still works for not recurring events. 
