### PR TITLE
Fix jQuery / Diazo issue: set proper response headers.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,8 @@ Changelog
 2.1.2 (unreleased)
 ------------------
 
+- Fix jQuery / Diazo issue: set proper response headers. [jone]
+
 - Added german translation for menuitem.
   [lknoepfel]
 

--- a/ftw/calendar/browser/calendar_config.pt
+++ b/ftw/calendar/browser/calendar_config.pt
@@ -1,5 +1,4 @@
-<tal:script i18n:domain="ftw.calendar" 
-    tal:define="set_mimetype python:request.response.setHeader('Content-Type', 'text/javascript');">
+<tal:script i18n:domain="ftw.calendar">
 $(document).ready(function() {
 	$('#calendar').fullCalendar({
 		header: {
@@ -87,7 +86,7 @@ $(document).ready(function() {
                     'dayDelta': dayDelta,
                     'minuteDelta': minuteDelta
                 },
-                success: function(msg) {      
+                success: function(msg) {
                 }
             });
         },

--- a/ftw/calendar/browser/calendar_config.py
+++ b/ftw/calendar/browser/calendar_config.py
@@ -6,11 +6,15 @@ class CalendarConfigView(BrowserView):
     Calendar configuration view.
     """
 
+    def __call__(self):
+        self.request.response.setHeader('X-Theme-Disabled', 'True')
+        return super(CalendarConfigView, self).__call__()
+
     def first_day(self):
         """
         Returns the first day of the week as an integer.
         """
-        
+
         calendar_tool = getToolByName(self.context, 'portal_calendar')
         first = calendar_tool.getFirstWeekDay()
         return (first < 6 and first + 1) or 0


### PR DESCRIPTION
For making diazo not render the (AJAX) response the content type text/javascript was set, which is wrong (it is actually html) and did confuse the jQuery parser.

The proper solution is to set the X-Theme-Disabled response header.