### PR TITLE
Remove dependency on ftw.testing[splinter]

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove dependency on ftw.testing[splinter] (has been dropped in ftw.testing). [lgraf]
 
 
 3.0.0 (2017-01-24)

--- a/ftw/calendar/testing.py
+++ b/ftw/calendar/testing.py
@@ -1,13 +1,13 @@
 from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
-from ftw.testing import FunctionalSplinterTesting
 from plone.app.testing import applyProfile
+from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from zope.configuration import xmlconfig
-import ftw.calendar.tests.builders
+import ftw.calendar.tests.builders  # noqa
 
 
 class FtwCalendarLayer(PloneSandboxLayer):
@@ -27,7 +27,7 @@ class FtwCalendarLayer(PloneSandboxLayer):
 FTW_CALENDAR_FIXTURE = FtwCalendarLayer()
 FTW_CALENDAR_INTEGRATION_TESTING = IntegrationTesting(
     bases=(FTW_CALENDAR_FIXTURE, ), name="FtwCalendar:Integration")
-FTW_CALENDAR_FUNCTIONAL_TESTING = FunctionalSplinterTesting(
+FTW_CALENDAR_FUNCTIONAL_TESTING = FunctionalTesting(
     bases=(FTW_CALENDAR_FIXTURE,
            set_builder_session_factory(functional_session_factory)),
     name="FtwCalendar:Functional")

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 
 version = '3.0.1.dev0'
 
-tests_require = ['ftw.testing [splinter]',
+tests_require = ['ftw.testing',
                  'ftw.builder',
                  'plone.app.testing',
                  'ftw.testbrowser',


### PR DESCRIPTION
This removes the dependency on the `ftw.testing[splinter]` extra, which has been [dropped from 
`ftw.testing`](https://github.com/4teamwork/ftw.testing/commit/6eadb49bed08a0b40113d65abf8b302935cb1007).