### PR TITLE
Remove inherited duplicat and correct order.

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -1,6 +1,5 @@
 [buildout]
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.3.x.cfg
-    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
 
 package-name = ftw.calendar

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -1,6 +1,5 @@
 [buildout]
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-5.1.x.cfg
-    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-versions.cfg
 
 package-name = ftw.calendar


### PR DESCRIPTION
The test-version cfg is inherited by the more specific cfg anyways.
By removing it the order problem will be resolved as well.