### PR TITLE
TypeError: Class advice impossible in Python3

### DIFF
--- a/ftw/calendar/browser/calendarupdateview.py
+++ b/ftw/calendar/browser/calendarupdateview.py
@@ -6,12 +6,12 @@ from plone import api
 from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
 from zope.component import getMultiAdapter
-from zope.interface import implements
+from zope.interface import implementer
 import simplejson as json
 
 
+@implementer(IFtwCalendarJSONSourceProvider)
 class CalendarJSONSource(object):
-    implements(IFtwCalendarJSONSourceProvider)
 
     def __init__(self, context, request):
         self.context = context


### PR DESCRIPTION
  File "/home/pacs/pro01/users/gymmar/plone6/eggs/zope.interface-5.5.2-py3.10-linux-x86_64.egg/zope/interface/declarations.py", line 778, in implements
    raise TypeError(_ADVICE_ERROR % 'implementer')
zope.configuration.xmlconfig.ZopeXMLConfigurationError: File "/home/pacs/pro01/users/gymmar/plone6/eggs/ftw.calendar-3.1.2-py3.10-linux-x86_64.egg/ftw/calendar/browser/configure.zcml", line 21.2-28.8
    File "/home/pacs/pro01/users/gymmar/plone6/parts/instance/etc/site.zcml", line 16.2-16.23
    File "/home/pacs/pro01/users/gymmar/plone6/eggs/Products.CMFPlone-6.0.0-py3.10.egg/Products/CMFPlone/configure.zcml", line 118.2-122.8
    File "/home/pacs/pro01/users/gymmar/plone6/eggs/ftw.calendar-3.1.2-py3.10-linux-x86_64.egg/ftw/calendar/configure.zcml", line 13.2-13.32
    TypeError: Class advice impossible in Python3.  Use the @implementer class decorator instead.